### PR TITLE
Fix PEP8 issues and adjust flake8 settings

### DIFF
--- a/blogicum/blog/urls.py
+++ b/blogicum/blog/urls.py
@@ -14,7 +14,11 @@ urlpatterns = [
     path('posts/create/', views.post_create, name='create_post'),
     path('posts/<int:post_id>/edit/', views.post_edit, name='edit_post'),
     path('posts/<int:post_id>/delete/', views.post_delete, name='delete_post'),
-    path('posts/<int:post_id>/comment/', views.comment_add, name='add_comment'),
+    path(
+        'posts/<int:post_id>/comment/',
+        views.comment_add,
+        name='add_comment',
+    ),
     path('posts/<int:post_id>/edit_comment/<int:comment_id>/',
          views.comment_edit, name='edit_comment'),
     path('posts/<int:post_id>/delete_comment/<int:comment_id>/',

--- a/blogicum/blogicum/urls.py
+++ b/blogicum/blogicum/urls.py
@@ -14,7 +14,10 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    urlpatterns += static(
+        settings.MEDIA_URL,
+        document_root=settings.MEDIA_ROOT,
+    )
 
 handler404 = 'pages.views.page_not_found'
 handler500 = 'pages.views.server_error'

--- a/blogicum/pages/views.py
+++ b/blogicum/pages/views.py
@@ -1,6 +1,8 @@
 from django.shortcuts import render
 
 # Кастомные обработчики ошибок
+
+
 def page_not_found(request, exception):
     return render(request, 'pages/404.html', status=404)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-max-line-lenght = 79
+max-line-length = 79
 max-complexity = 10
 ignore =
     W503,


### PR DESCRIPTION
## Summary
- remove unused imports and reformat long lines in views
- correct flake8 configuration and wrap URL patterns
- add blank lines to meet PEP8 in pages views

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8277cd828832686e2d8992d96d280